### PR TITLE
Fix useHookstate store switchover

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.0.0",
+    "configurations": [
+      {
+        "name": "Test Core",
+        "request": "launch",
+        "runtimeArgs": [
+          "nx",
+          "test",
+          "core"
+        ],
+        "runtimeExecutable": "pnpm",
+        "skipFiles": [
+          "<node_internals>/**"
+        ],
+        "type": "node"
+      }
+    ]
+  }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This is the mono repository, which combine the Hookstate core package, extension
 
 From the repository root directory:
 
-- `npm install -f pnpm` - install pnpm tool
+- `npm install -g pnpm` - install pnpm tool
 - `pnpm install` - install node_modules for all packages
 
 - `pnpm nx <script> <package>` - run script for a package as well as build dependencies if required, for example:

--- a/core/src/__tests__/Complex.tsx
+++ b/core/src/__tests__/Complex.tsx
@@ -224,6 +224,13 @@ test('scoped: should reinitialize when parent state changes', async () => {
 
     expect(renderTimes).toBe(3);
     expect(result.current.get()).toBe(1); // Should reinitialize to new store's value
+
+    // should be able to set state after reinitialization
+    act(() => {
+        result.current.set(p => p + 1);
+    });
+
+    expect(result.current.get()).toBe(2);
 });
 
 test('should synchronize unsubscription and reinitialization when source/store changes', async () => {
@@ -250,6 +257,13 @@ test('should synchronize unsubscription and reinitialization when source/store c
 
     expect(renderTimes).toBe(3);
     expect(result.current.get()).toBe(42); // Should reinitialize to new store's value
+
+    // should be able to set state after reinitialization
+    act(() => {
+        result.current.set(p => p + 1);
+    });
+
+    expect(result.current.get()).toBe(43);
 });
 
 test('local: should reinitialize when initial state changes', async () => {
@@ -273,4 +287,11 @@ test('local: should reinitialize when initial state changes', async () => {
 
     expect(renderTimes).toBe(3);
     expect(result.current.a.get()).toBe(1); // Should reinitialize to new initial state
+
+    // should be able to set state after reinitialization
+    act(() => {
+        result.current.a.set(p => p + 1);
+    });
+
+    expect(result.current.a.get()).toBe(2);
 });

--- a/core/src/__tests__/Extension.tsx
+++ b/core/src/__tests__/Extension.tsx
@@ -405,7 +405,6 @@ test('extension: common flow callbacks global state', async () => {
     act(() => {
         result.current[0].f1.set(p => p + 1)
     });
-    expect(console.warn).toHaveBeenCalledWith(`Warning: HOOKSTATE-106: Attempt to set state when it is destroyed. [path: /0/f1]`)
     expect(renderTimes).toStrictEqual(7);
     expect(result.current.get()[0].f1).toStrictEqual(1);
     expect(messages).toEqual([])

--- a/core/src/__tests__/Extension.tsx
+++ b/core/src/__tests__/Extension.tsx
@@ -191,12 +191,13 @@ test('extension: common flow callbacks', async () => {
     expect(messages).toEqual([])
     messages.splice(0, messages.length);
 
+    console.warn = jest.fn()
     act(() => {
-        expect(() => result.current[0].f1.set(p => p + 1)).toThrow(
-            'Error: HOOKSTATE-106 [path: /0/f1]. See https://hookstate.js.org/docs/exceptions#hookstate-106'
-        );
+        result.current[0].f1.set(10)
     });
+    expect(console.warn).toHaveBeenCalledWith(`Warning: HOOKSTATE-106: Attempt to set state when it is destroyed. [path: /0/f1]`)
     expect(renderTimes).toStrictEqual(7);
+    expect(result.current.get()[0].f1).toStrictEqual(10);
     expect(messages).toEqual([])
     messages.splice(0, messages.length);
 });
@@ -399,12 +400,14 @@ test('extension: common flow callbacks global state', async () => {
     expect(messages).toEqual([])
     messages.splice(0, messages.length);
 
+
+    console.warn = jest.fn()
     act(() => {
-        expect(() => result.current[0].f1.set(p => p + 1)).toThrow(
-            'Error: HOOKSTATE-106 [path: /0/f1]. See https://hookstate.js.org/docs/exceptions#hookstate-106'
-        );
+        result.current[0].f1.set(p => p + 1)
     });
+    expect(console.warn).toHaveBeenCalledWith(`Warning: HOOKSTATE-106: Attempt to set state when it is destroyed. [path: /0/f1]`)
     expect(renderTimes).toStrictEqual(7);
+    expect(result.current.get()[0].f1).toStrictEqual(1);
     expect(messages).toEqual([])
     messages.splice(0, messages.length);
 });

--- a/core/src/__tests__/Extension.tsx
+++ b/core/src/__tests__/Extension.tsx
@@ -195,7 +195,6 @@ test('extension: common flow callbacks', async () => {
     act(() => {
         result.current[0].f1.set(10)
     });
-    expect(console.warn).toHaveBeenCalledWith(`Warning: HOOKSTATE-106: Attempt to set state when it is destroyed. [path: /0/f1]`)
     expect(renderTimes).toStrictEqual(7);
     expect(result.current.get()[0].f1).toStrictEqual(10);
     expect(messages).toEqual([])

--- a/core/src/__tests__/Primitive.tsx
+++ b/core/src/__tests__/Primitive.tsx
@@ -236,7 +236,7 @@ test('primitive: global state created locally', async () => {
         result.current!.set(p => p + 1);
     });
     expect(renderTimes).toStrictEqual(2);
-    expect(errorMessage).toStrictEqual("Error: Error: HOOKSTATE-111 [path: /]. See https://hookstate.js.org/docs/exceptions#hookstate-111")
+    expect(errorMessage).toStrictEqual("")
 });
 
 test('primitive: stale state should auto refresh', async () => {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -679,7 +679,7 @@ export function useHookstate<S, E extends {} = {}>(
             let initializer = () => {
                 // warning: this is called twice in react strict mode
                 let store = parentMethods.store
-                let onSetUsedCallback = () => setValue({
+                let onSetUsedCallback = () => value.state.isMounted && setValue({
                     store: store, // immutable
                     state: state, // immutable
                     source: value.source // mutable, get the latest from value
@@ -750,7 +750,7 @@ export function useHookstate<S, E extends {} = {}>(
         let initializer = () => {
             // warning: this is called twice in react strict mode
             let store = createStore(source)
-            let onSetUsedCallback = () => setValue({
+            let onSetUsedCallback = () => value.state.isMounted && setValue({
                 store: store,
                 state: state,
             })

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -287,7 +287,7 @@ export type InferReturnType<V> = V extends (...args: any) => (infer R) ? InferRe
  * [Learn more about nested states...](https://hookstate.js.org/docs/nested-state)
  */
 export type State<S, E = {}> = __State<S, E> & StateMethods<S, E> & E & (
-    S extends ReadonlyArray<(infer U)> ? ReadonlyArray<State<U, E>> :
+    S extends ReadonlyArray<infer U> ? ReadonlyArray<State<U, E>> :
     S extends object ? Omit<
         { readonly [K in keyof Required<S>]: State<S[K], E>; },
         keyof StateMethods<S, E> | InferKeysOfType<S, Function> | keyof E
@@ -953,7 +953,7 @@ class Store implements Subscribable {
 
     private _promise?: Promise<StateValueAtRoot>;
     private _promiseResolver?: (_: StateValueAtRoot) => void;
-    private _promiseError?: StateValueAtRoot;
+    private _promiseError?: StateValueAtPath;
 
     constructor(private _value: StateValueAtRoot) {
         if (Object(_value) === _value &&
@@ -1064,11 +1064,7 @@ class Store implements Subscribable {
     }
 
     set(path: Path, value: StateValueAtPath): SetActionDescriptor {
-        if (this.edition < 0) {
-            // TODO convert to console log
-            // throw new StateInvalidUsageError(path, ErrorId.SetStateWhenDestroyed)
-            console.warn(`Warning: HOOKSTATE-106: Attempt to set state when it is destroyed. [path: /${path.join('/')}]`)
-        }
+
 
         if (path.length === 0) {
             // Root value UPDATE case,

--- a/docs/index/docs/50-exceptions.md
+++ b/docs/index/docs/50-exceptions.md
@@ -102,7 +102,9 @@ More information about [asynchronous states](./asynchronous-state).
 
 ## HOOKSTATE-106
 
-Happens when state is set after destroy. Typically it may happen when a component is unmounted but leaves asynchronous operations running, which trigger state updates when awaited finally.
+Deprecated in Hookstate 4.0.2. Now, setting state after unmount no longer throws an exception, which matches the behavior of React 18. 
+
+In prior versions of Hookstate, this exception happens when state is set after destroy. Typically it may happen when a component is unmounted but leaves asynchronous operations running, which trigger state updates when awaited finally.
 
 ```tsx
 const state = hookstate(...)


### PR DESCRIPTION
This PR adds support for store switchovers to useHookstate() for global and nested state. Local state behavior remains unchanged. Additionally, setting state after unmount no longer throws an error, which is more in line w/ how React's built-in useState hook works.  

TLDR; Eliminated HOOKSTATE-111 and HOOKSTATE-106 exceptions. 

closes #364 